### PR TITLE
Store SFPlot datasets by reference

### DIFF
--- a/include/SFGraphing/SFPlot.h
+++ b/include/SFGraphing/SFPlot.h
@@ -10,6 +10,7 @@
 #include "PlotDataSet.h"
 #include <algorithm>
 #include <cmath>
+#include <functional>
 #include <iomanip>
 #include <sstream>
 
@@ -23,7 +24,7 @@ private:
 
     float _margin;
 
-    std::vector<PlotDataSet> _plotDataSets;
+    std::vector<std::reference_wrapper<const PlotDataSet>> _plotDataSets;
 
     sf::Font _font;
 

--- a/src/SFPlot.cpp
+++ b/src/SFPlot.cpp
@@ -52,7 +52,7 @@ void SFPlot::SetupAxes()
     float xmin = INFINITY;
     float ymin = INFINITY;
 
-    for (const auto& dataset : _plotDataSets)
+    for (const PlotDataSet& dataset : _plotDataSets)
     {
         std::vector<float> setXAxis = dataset.GetXValues();
         std::vector<float> setYAxis = dataset.GetYValues();
@@ -73,7 +73,7 @@ void SFPlot::SetupAxes()
     float xmax = -INFINITY;
     float ymax = -INFINITY;
 
-    for (const auto& dataset : _plotDataSets)
+    for (const PlotDataSet& dataset : _plotDataSets)
     {
         std::vector<float> setXAxis = dataset.GetXValues();
         std::vector<float> setYAxis = dataset.GetYValues();
@@ -119,7 +119,7 @@ void SFPlot::SetupAxes(const float& xmin, const float& xmax, const float& ymin, 
 
 void SFPlot::AddDataSet(const PlotDataSet& data_set)
 {
-    _plotDataSets.push_back(data_set);
+    _plotDataSets.push_back(std::ref(data_set));
 }
 
 void SFPlot::GenerateVertices()
@@ -222,7 +222,7 @@ void SFPlot::GenerateVertices()
      */
 
     sf::Vector2f legendPos = sf::Vector2f(_origin + sf::Vector2f(_dimension.x - 5, 0));
-    for (const auto& dataset : _plotDataSets)
+    for (const PlotDataSet& dataset : _plotDataSets)
     {
         //Generate legend
         sf::Text segmentLegend;


### PR DESCRIPTION
Currently, `_plotDataSets` is stored as a vector of value, meaning data sets are actually copies of their original object. This creates the somewhat surprising behavior that modifying the underlying `PlotDataSet` instantiation has no effect on the graph when redrawn.

It seem like this is circumvented in the example by creating a new `SFPlot` object on every loop, but that felt somewhat wasteful. Now the library can be used for continuously updating graphs like so:

```cpp
// One-time initialization
SFPlot plot(...);
PlotDataSet data(...);
plot.AddDataSet(data);

// Render loop
while (window.isOpen()) {
  // ...

  // Modify dataset - add, remove, or replace
  data.PushPair(...)

  // Drawing the plot now picks up these data changes
  plot.GenerateVertices()
  window.draw(plot)

  // ...
}
```

Because the datasets are now stored by reference, updating them externally will cause the graph to also update - and the plot object can be reused across renders. Up to you whether you think this aligns with the intended usage pattern for the project - happy to drop this is you prefer the current approach.